### PR TITLE
Fix bug in handling of initializer options and update dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'bundler'
 

--- a/lib/riak/session_store.rb
+++ b/lib/riak/session_store.rb
@@ -1,6 +1,6 @@
 
 require 'riak'
-require 'rack/session/abstract/id'
+require 'action_dispatch/middleware/session/abstract_store'
 
 module Riak
   # Lets you store web application session data in Riak.
@@ -17,8 +17,8 @@ module Riak
   #   config.middleware.swap ActionController::Session::CookieStore, Riak::SessionStore
   #
   # For configuration options, see #initialize.
-  class SessionStore < Rack::Session::Abstract::ID
-    DEFAULT_OPTIONS = Rack::Session::Abstract::ID::DEFAULT_OPTIONS.merge \
+  class SessionStore < ActionDispatch::Session::AbstractStore
+    DEFAULT_OPTIONS = ActionDispatch::Session::AbstractStore::DEFAULT_OPTIONS.merge \
     :host => "127.0.0.1",
     :http_port => 8098,
     :bucket => "_sessions",

--- a/lib/ripple/session_store.rb
+++ b/lib/ripple/session_store.rb
@@ -12,7 +12,7 @@ module Ripple
   class SessionStore < ActionDispatch::Session::AbstractStore
     def initialize(app, options={})
       super
-      @default_options = {
+      @default_options = options.merge({
         :bucket => "_sessions",
         :r => 1,
         :w => 1,
@@ -22,7 +22,7 @@ module Ripple
         :last_write_wins => false,
         :host => "127.0.0.1",
         :http_port => 8098
-      }.merge(@default_options)
+      })
       @client = Riak::Client.new(@default_options.slice(*Riak::Client::VALID_OPTIONS))
       @bucket = @client.bucket(@default_options[:bucket])
       set_bucket_defaults

--- a/riak-sessions.gemspec
+++ b/riak-sessions.gemspec
@@ -12,12 +12,12 @@ Gem::Specification.new do |gem|
   gem.authors = ["Sean Cribbs"]
 
   # Deps
-  gem.add_development_dependency "rspec", "~>2.6.0"
-  gem.add_development_dependency "rspec-rails", "~>2.6.0"
+  gem.add_development_dependency "rspec", "~>2.13"
+  gem.add_development_dependency "rspec-rails", "~>2.13"
   gem.add_development_dependency "yajl-ruby"
   gem.add_development_dependency "rails", "~>3.0.0"
   gem.add_development_dependency "rake"
-  gem.add_dependency "riak-client", "~> 1.0.0"
+  gem.add_dependency "riak-client", ">= 2.0"
   gem.add_dependency "rack", ">=1.0"
 
   # Files


### PR DESCRIPTION
The session store initializer doesn't honor the options passed as arguments, because the code ignore them.
